### PR TITLE
make sure we only mock necessary requests

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -17,9 +17,6 @@ parserOptions:
 globals:
   PACKAGE: yes
   VERSION: yes
-  IS_PRODUCTION: yes
-  IS_DEVELOPMENT: yes
-  IS_TEST: yes
 plugins:
   - better
   - filenames

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,9 +3,6 @@ module.exports = {
   moduleFileExtensions: ['js'],
   globals: {
     'process.env.NODE_ENV': 'test',
-    IS_PRODUCTION: false,
-    IS_DEVELOPMENT: false,
-    IS_TEST: true,
   },
   transformIgnorePatterns: [
     'node_modules/(?!(babel-plugin-transform-polyfills)/)',

--- a/rollup.config.dev.js
+++ b/rollup.config.dev.js
@@ -13,9 +13,6 @@ const createBaseConfig = common => specific => {
     plugins: base.plugins.concat([
       replace({
         'process.env.NODE_ENV': JSON.stringify('development'),
-        IS_PRODUCTION: JSON.stringify(false),
-        IS_DEVELOPMENT: JSON.stringify(true),
-        IS_TEST: JSON.stringify(false),
       }),
     ]),
   })

--- a/rollup.config.prod.js
+++ b/rollup.config.prod.js
@@ -15,9 +15,6 @@ const createBaseConfig = common => specific => {
     plugins: base.plugins.concat([
       replace({
         'process.env.NODE_ENV': JSON.stringify('production'),
-        IS_PRODUCTION: JSON.stringify(true),
-        IS_DEVELOPMENT: JSON.stringify(false),
-        IS_TEST: JSON.stringify(false),
       }),
       uglify(
         {

--- a/src/Skedify.test.js
+++ b/src/Skedify.test.js
@@ -713,4 +713,44 @@ describe('API', () => {
       expect(readRequest).toMatchSnapshot()
     })
   })
+
+  describe('API/testUtils', () => {
+    describe('mockResponse', () => {
+      it('should be possible to mock a response (and get defaults)', async () => {
+        mockResponse()
+
+        expect(await SDK.appointments()).toMatchSnapshot()
+      })
+
+      it('should be possible to mock a response', async () => {
+        mockResponse(
+          'data goes here',
+          'meta data goes here',
+          'warnings go here',
+          223 // Some random 2XX status code to prove that we can mock it
+        )
+
+        expect(await SDK.appointments()).toMatchSnapshot()
+      })
+
+      it('should be possible to mock responses of multiple calls', async () => {
+        mockResponse('my appointments data')
+        expect(await SDK.appointments()).toMatchSnapshot()
+
+        mockResponse('my subjects data')
+        expect(await SDK.subjects()).toMatchSnapshot()
+      })
+    })
+
+    describe('matchRequest', () => {
+      it('should be possible to get the request object', async () => {
+        expect(await matchRequest(SDK.appointments())).toMatchSnapshot()
+      })
+
+      it('should be possible to match multiple requests in one go', async () => {
+        expect(await matchRequest(SDK.appointments())).toMatchSnapshot()
+        expect(await matchRequest(SDK.appointments())).toMatchSnapshot()
+      })
+    })
+  })
 })

--- a/src/__snapshots__/Skedify.test.js.snap
+++ b/src/__snapshots__/Skedify.test.js.snap
@@ -446,6 +446,88 @@ exports[`API API/Resources should throw an error when no values are passed for t
 
 exports[`API API/Resources should throw an error when required props are missing from a shorthand call (timetable) 1`] = `"[RESOURCE]: You tried to call .timetable({\\"subject\\":316,\\"end\\":\\"2017-12-26\\"}) but \`office\` and \`start\` are also required."`;
 
+exports[`API API/testUtils matchRequest should be possible to get the request object 1`] = `
+Object {
+  "data": undefined,
+  "headers": Object {
+    "Accept": "application/json, text/plain, */*",
+    "Accept-Language": "nl-BE, nl;q=0.667, *;q=0.333",
+    "Authorization": "Bearer fake_example_access_token",
+  },
+  "method": "get",
+  "params": undefined,
+  "url": "https://api.example.com/appointments",
+}
+`;
+
+exports[`API API/testUtils matchRequest should be possible to match multiple requests in one go 1`] = `
+Object {
+  "data": undefined,
+  "headers": Object {
+    "Accept": "application/json, text/plain, */*",
+    "Accept-Language": "nl-BE, nl;q=0.667, *;q=0.333",
+    "Authorization": "Bearer fake_example_access_token",
+  },
+  "method": "get",
+  "params": undefined,
+  "url": "https://api.example.com/appointments",
+}
+`;
+
+exports[`API API/testUtils matchRequest should be possible to match multiple requests in one go 2`] = `
+Object {
+  "data": undefined,
+  "headers": Object {
+    "Accept": "application/json, text/plain, */*",
+    "Accept-Language": "nl-BE, nl;q=0.667, *;q=0.333",
+    "Authorization": "Bearer fake_example_access_token",
+  },
+  "method": "get",
+  "params": undefined,
+  "url": "https://api.example.com/appointments",
+}
+`;
+
+exports[`API API/testUtils mockResponse should be possible to mock a response (and get defaults) 1`] = `
+Object {
+  "data": undefined,
+  "headers": undefined,
+  "meta": undefined,
+  "status": 200,
+  "warnings": undefined,
+}
+`;
+
+exports[`API API/testUtils mockResponse should be possible to mock a response 1`] = `
+Object {
+  "data": "data goes here",
+  "headers": undefined,
+  "meta": "meta data goes here",
+  "status": 223,
+  "warnings": "warnings go here",
+}
+`;
+
+exports[`API API/testUtils mockResponse should be possible to mock responses of multiple calls 1`] = `
+Object {
+  "data": "my appointments data",
+  "headers": undefined,
+  "meta": undefined,
+  "status": 200,
+  "warnings": undefined,
+}
+`;
+
+exports[`API API/testUtils mockResponse should be possible to mock responses of multiple calls 2`] = `
+Object {
+  "data": "my subjects data",
+  "headers": undefined,
+  "meta": undefined,
+  "status": 200,
+  "warnings": undefined,
+}
+`;
+
 exports[`API should expose all available includes on the Skedify.API instance 1`] = `
 Object {
   "accepted_possibility": Object {

--- a/src/createIdentityProvider/identityProviders/Client.js
+++ b/src/createIdentityProvider/identityProviders/Client.js
@@ -37,10 +37,10 @@ export default class Client {
     }
   }
 
-  getAuthorization(force = false) {
+  getAuthorization() {
     const { client_id, realm, resource_code } = this._options
 
-    if (this._current === undefined || force) {
+    if (this._current === undefined) {
       this._current = retry(
         (resolve, reject) => {
           if (resource_code !== undefined) {

--- a/src/decorators/withResources/Resource.js
+++ b/src/decorators/withResources/Resource.js
@@ -11,8 +11,6 @@ import createRequest from './createRequest'
 import executeResponseInterceptors from './executeResponseInterceptors'
 import clone from './clone'
 
-const SHOULD_FORCE_AUTHORIZATION_REQUEST = IS_TEST
-
 function overrideThen(resource, replaceWith) {
   const originalThen = resource.then.bind(resource)
 
@@ -151,7 +149,7 @@ export default class Resource {
     const { identityProvider } = get(instance)
 
     return identityProvider
-      .getAuthorization(SHOULD_FORCE_AUTHORIZATION_REQUEST)
+      .getAuthorization()
       .then(createRequest.bind(null, this))
       .then(normalizeResponse)
       .then(executeResponseInterceptors.bind(null, this))

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -4,41 +4,39 @@ const WAIT_TIME = 0
 
 export function mockResponse(data, meta, warnings, status = 200) {
   // Mock the authentication request
+  moxios.stubRequest(/access_tokens/, {
+    status: 200,
+    response: {
+      access_token: 'fake_example_access_token',
+      token_type: 'Bearer',
+      expires_in: 5400,
+    },
+  })
+
+  // Mock the proxy call
+  moxios.stubRequest(/\/integrations\/proxy/, {
+    status: 200,
+    response: {
+      data: {
+        // We need to use a getter to delay the execution of this function
+        // We need access to the mostRecent request, but if there is no most recent
+        // Request we can't access its url. Therefor once we are sure the /integrations/proxy
+        // Is executed, we can safely run the mostRecent() function.
+        get url() {
+          return moxios.requests
+            .mostRecent()
+            .url.replace('/integrations/proxy', '')
+        },
+      },
+    },
+  })
+
+  // Mock the actual request
   moxios.wait(() => {
     moxios.requests.mostRecent().respondWith({
-      status: 200,
-      response: {
-        access_token: 'fake_example_access_token',
-        token_type: 'Bearer',
-        expires_in: 5400,
-      },
+      status,
+      response: { data, meta, warnings },
     })
-
-    // We assume here that the url used to request access_tokens is the base url
-    // minus the `/access_tokens`. This is easier when we test configuration changes.
-    const proxy_url = moxios.requests
-      .mostRecent()
-      .config.url.replace('/access_tokens', '')
-
-    // Mock the proxy call
-    moxios.wait(() => {
-      moxios.requests.mostRecent().respondWith({
-        status: 200,
-        response: {
-          data: {
-            url: proxy_url,
-          },
-        },
-      })
-
-      // Mock the actual request
-      moxios.wait(() => {
-        moxios.requests.mostRecent().respondWith({
-          status,
-          response: { data, meta, warnings },
-        })
-      }, WAIT_TIME)
-    }, WAIT_TIME)
   }, WAIT_TIME)
 }
 


### PR DESCRIPTION
- It will mock the access_tokens call when it sees it
- It will mock the proxy call when it sees it
- It will cleanup some general things like injected constants