### PR TITLE
feat: add mostRecentRequest and mockedRequests test-utils

### DIFF
--- a/src/__snapshots__/Skedify.test.js.snap
+++ b/src/__snapshots__/Skedify.test.js.snap
@@ -598,6 +598,103 @@ Object {
 }
 `;
 
+exports[`API API/testUtils mockedRequests should list all the requests 1`] = `
+Array [
+  Object {
+    "data": undefined,
+    "headers": Object {
+      "Accept": "application/json, text/plain, */*",
+      "Accept-Language": "nl-BE, nl;q=0.667, *;q=0.333",
+      "Authorization": "Bearer fake_example_access_token",
+    },
+    "method": "get",
+    "params": undefined,
+    "url": "https://api.example.com/appointments",
+  },
+  Object {
+    "data": undefined,
+    "headers": Object {
+      "Accept": "application/json, text/plain, */*",
+      "Accept-Language": "nl-BE, nl;q=0.667, *;q=0.333",
+      "Authorization": "Bearer fake_example_access_token",
+    },
+    "method": "get",
+    "params": undefined,
+    "url": "https://api.example.com/subjects",
+  },
+  Object {
+    "data": undefined,
+    "headers": Object {
+      "Accept": "application/json, text/plain, */*",
+      "Accept-Language": "nl-BE, nl;q=0.667, *;q=0.333",
+      "Authorization": "Bearer fake_example_access_token",
+    },
+    "method": "get",
+    "params": undefined,
+    "url": "https://api.example.com/employees",
+  },
+]
+`;
+
+exports[`API API/testUtils mostRecentRequest should return the latest request 1`] = `
+Object {
+  "data": Object {
+    "value": "x",
+  },
+  "headers": Object {
+    "Accept": "application/json, text/plain, */*",
+    "Accept-Language": "nl-BE, nl;q=0.667, *;q=0.333",
+    "Authorization": "Bearer fake_example_access_token",
+    "Content-Type": "application/json;charset=utf-8",
+  },
+  "method": "post",
+  "params": undefined,
+  "url": "https://api.example.com/appointments",
+}
+`;
+
+exports[`API API/testUtils mostRecentRequest should return the latest request with multiple SDKs 1`] = `
+Object {
+  "data": undefined,
+  "headers": Object {
+    "Accept": "application/json, text/plain, */*",
+    "Accept-Language": "nl-BE, nl;q=0.667, *;q=0.333",
+    "Authorization": "Bearer fake_example_access_token",
+  },
+  "method": "get",
+  "params": undefined,
+  "url": "https://api.example.com/appointments",
+}
+`;
+
+exports[`API API/testUtils mostRecentRequest should return the latest request with multiple SDKs 2`] = `
+Object {
+  "data": undefined,
+  "headers": Object {
+    "Accept": "application/json, text/plain, */*",
+    "Accept-Language": "nl-BE, nl;q=0.667, *;q=0.333",
+    "Authorization": "Bearer fake_example_access_token",
+  },
+  "method": "get",
+  "params": undefined,
+  "url": "https://api.example.com/subjects",
+}
+`;
+
+exports[`API API/testUtils mostRecentRequest should return the latest request with multiple SDKs 3`] = `
+Object {
+  "data": undefined,
+  "headers": Object {
+    "Accept": "application/json, text/plain, */*",
+    "Accept-Language": "nl-BE, nl;q=0.667, *;q=0.333",
+    "Authorization": "Bearer fake_example_access_token",
+  },
+  "method": "get",
+  "params": undefined,
+  "url": "https://api.example.com/employees",
+}
+`;
+
 exports[`API should be possible to create an employee 1`] = `
 Object {
   "data": Object {},

--- a/src/build/Skedify.testing.js
+++ b/src/build/Skedify.testing.js
@@ -8,6 +8,8 @@ export {
   matchRequest,
   mockResponse,
   mockMatchingURLResponse,
+  mostRecentRequest,
+  mockedRequests,
 } from '../../test/testUtils'
 
 /**

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -33,6 +33,18 @@ function stubCommonRequests() {
   })
 }
 
+function mapRequestConfig(config) {
+  const { data, headers, method, params, url } = config
+
+  return {
+    data: data && JSON.parse(data),
+    headers,
+    method,
+    params,
+    url,
+  }
+}
+
 export function mockMatchingURLResponse(
   urlOrRegExp,
   data,
@@ -73,6 +85,15 @@ export function mockResponse(data, meta, warnings, status = 200) {
   }, WAIT_TIME)
 }
 
+export function mostRecentRequest() {
+  const { config } = moxios.requests.mostRecent()
+  return mapRequestConfig(config)
+}
+
+export function mockedRequests() {
+  return moxios.requests.__items.map(({ config }) => mapRequestConfig(config))
+}
+
 export function matchRequest(
   promise,
   fakeData,
@@ -81,22 +102,5 @@ export function matchRequest(
   fakeStatus
 ) {
   mockResponse(fakeData, fakeMeta, fakeWarnings, fakeStatus)
-
-  return promise.then(() => {
-    const {
-      data,
-      headers,
-      method,
-      params,
-      url,
-    } = moxios.requests.mostRecent().config
-
-    return {
-      data: data && JSON.parse(data),
-      headers,
-      method,
-      params,
-      url,
-    }
-  })
+  return promise.then(() => mostRecentRequest())
 }


### PR DESCRIPTION
This PR adds two new test-utils: mostRecentRequest and mockedRequests

- **mostRecentRequest**: retrieves the latest request
- **mockedRequests**: get a list of all the mocked requests