### PR TITLE
fix: add 'external_customer_id' to stringifier exceptions

### DIFF
--- a/src/util/convertIdsToString.js
+++ b/src/util/convertIdsToString.js
@@ -1,4 +1,4 @@
-const EXCEPTIONS = ['external_id']
+const EXCEPTIONS = ['external_id', 'external_customer_id']
 
 export default function convertIdsToString(json) {
   if (json === null) {

--- a/src/util/convertIdsToString.test.js
+++ b/src/util/convertIdsToString.test.js
@@ -54,11 +54,17 @@ describe('convertIdsToString', () => {
   })
 
   it('should skip conversion of **_id values when it is one of the exceptions', () => {
-    const response = { example_id: 1, something_else: 2, external_id: 3 }
+    const response = {
+      example_id: 1,
+      something_else: 2,
+      external_id: 3,
+      external_customer_id: { order: 0 },
+    }
     expect(convertIdsToString(response)).toEqual({
       example_id: '1',
       something_else: 2,
       external_id: 3, // This is an exception
+      external_customer_id: { order: 0 }, // This is also an exception
     })
   })
 


### PR DESCRIPTION
> See JIRA https://skedify.atlassian.net/browse/SKED-

<!--  
In an effort to increase security awareness we want to remind ourselves to pay attention to security when writing code.
👉 Mark this checkbox if you payed attention to security.
-->
- [x] Security Awareness Checkbox 🛡️


`enterpriseSettings.returning_customer_fields.external_customer_id` is being turned into a string while it's expected to be an object.
eg:
```
external_customer_id: "[object Object]"
```


I am not sure of this field name is used for another response where it should be stringified, Is there a way to search possible responses from the API somewhere?

Maybe safer fix: check if *_id field is an object/array before attempting to stringify, if this is the case skip stringifying, it'll lead to incorrect behaviour anyway