### PR TITLE
feat(delete requests): allow delete requests to also pass in data

### DIFF
--- a/src/decorators/withResources/Resource.js
+++ b/src/decorators/withResources/Resource.js
@@ -255,7 +255,7 @@ export default class Resource {
     return cloned
   }
 
-  delete() {
+  delete(data) {
     if (!isAllowed(this, HTTP_VERB_DELETE)) {
       throw createConfigError(
         `You tried to call \`.delete()\` but this method is currently not allowed.`
@@ -274,6 +274,7 @@ export default class Resource {
       requestConfig: Object.assign({}, requestConfig, {
         method: HTTP_VERB_DELETE,
         name: 'delete',
+        data,
       }),
     }))
 


### PR DESCRIPTION
Currently in web-admin, I have to loop over all ContactOfficeSubjects separately to delete them, as the SDK ignores any parameters passed in currently.

This allows consumers to pass in data to be forwarded to the delete call, so bulk deletes are possible